### PR TITLE
fix: temporary distributed context to handle pipeline-parallel megatron checkpoint

### DIFF
--- a/nemo_rl/models/megatron/community_import.py
+++ b/nemo_rl/models/megatron/community_import.py
@@ -104,9 +104,20 @@ def export_model_from_megatron(
             f"HF checkpoint already exists at {output_path}. Delete it to run or set overwrite=True."
         )
 
+    try:
+        from megatron.bridge.training.model_load_save import temporary_distributed_context
+    except ImportError:
+        raise ImportError("megatron.bridge.training is not available.")
+
     bridge = AutoBridge.from_hf_pretrained(hf_model_name, trust_remote_code=True)
-    megatron_model = bridge.load_megatron_model(input_path)
-    bridge.save_hf_pretrained(megatron_model, output_path)
+    
+    # Export performs on CPU with proper distributed context
+    with temporary_distributed_context(backend="gloo"):
+        # Load the Megatron model
+        megatron_model = bridge.load_megatron_model(input_path, skip_temp_dist_context=True)
+        
+        # Save in HuggingFace format
+        bridge.save_hf_pretrained(megatron_model, output_path)
 
     # resetting mcore state
     import megatron.core.rerun_state_machine


### PR DESCRIPTION
# What does this PR do ?

When running conversion script, the parallel context gets lost

rank0]:   File "/mnt/vast/home/stan/git/RL/3rdparty/Megatron-LM-workspace/Megatron-LM/megatron/core/parallel_state.py", line 1288, in get_pipeline_model_parallel_group
[rank0]:     _PIPELINE_MODEL_PARALLEL_GROUP is not None
[rank0]: AssertionError: pipeline_model parallel group is not initialized

Now context wraps both model loading and HF saving operations within the same temporary distributed context to ensure the pipeline parallel group remains initialized throughout the conversion process, preventing the "pipeline_model parallel group is not initialized" AssertionError.
